### PR TITLE
Add -s option to Curl to not print download when check

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -34,7 +34,7 @@ metadataUrl="$url/${groupId//.//}/$artifactId/maven-metadata.xml"
 
 pattern=$([ -z "$version" ] && echo "\$p" || echo "/^$version\$/,\$p")
 
-curl $auth $metadataUrl \
+curl -s $auth $metadataUrl \
   | xmllint --xpath "/metadata/versioning/versions/version" - \
   | awk -F'</?version>' '{for(i=2;i<=NF;i++) if ($i != "") print $i}' \
   | sed -n "${pattern}" \


### PR DESCRIPTION
When we try to use check resource, the `check` will print following output on stdout:

```bash

 % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   336  100   336    0     0   2173      0 --:--:-- --:--:-- --:--:--  2470
[
  {
    "version": "1.2.0-SNAPSHOT"
  }
]
``` 
This output make check fail concourse.

This patch add -s option to `curl` which silent the download print.