### PR TITLE
Allow to use Curl in insecure mode to Check throw HTTPS

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -34,7 +34,7 @@ metadataUrl="$url/${groupId//.//}/$artifactId/maven-metadata.xml"
 
 pattern=$([ -z "$version" ] && echo "\$p" || echo "/^$version\$/,\$p")
 
-curl -s $auth $metadataUrl \
+curl -k -s $auth $metadataUrl \
   | xmllint --xpath "/metadata/versioning/versions/version" - \
   | awk -F'</?version>' '{for(i=2;i<=NF;i++) if ($i != "") print $i}' \
   | sed -n "${pattern}" \


### PR DESCRIPTION
Currently, the base image not provide collection of ca cert which
allow to make a fully secured connection, validating cert issuer.

This commit allow config curl with the `--insecure`option