### PR TITLE
Fix/check output bad destination

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -8,6 +8,14 @@ exec 1>&2 # redirect all output to stderr for logging
 
 source $(dirname $0)/common.sh
 
+source=$1
+
+if [ -z "$source" ]; then
+  source=$(mktemp -d '/tmp/source.XXXXXX')
+fi
+
+cd $source
+
 # for jq
 PATH=/usr/local/bin:$PATH
 
@@ -57,4 +65,4 @@ else
   done
 fi
 
-printf "%s\n" "${versions[@]}" | sed 's/.*/{ "version": "&" }/' | jq --slurp .
+printf "%s\n" "${versions[@]}" | sed 's/.*/{ "version": "&" }/' | jq --slurp . >&3

--- a/assets/check
+++ b/assets/check
@@ -8,14 +8,6 @@ exec 1>&2 # redirect all output to stderr for logging
 
 source $(dirname $0)/common.sh
 
-source=$1
-
-if [ -z "$source" ]; then
-  source=$(mktemp -d '/tmp/source.XXXXXX')
-fi
-
-cd $source
-
 # for jq
 PATH=/usr/local/bin:$PATH
 


### PR DESCRIPTION
Final output isn't send to >3&. This PR fix it, allowing to use `maven-resource` when done `check`on `concourse`.