### PR TITLE
Introduce workaround for missing Java certificates after invention of Concourse Certificate Propagation

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -79,7 +79,9 @@ elif [ -n "$repository_cert" ]; then
   mkdir -p $working/security
   echo "$repository_cert" > $working/security/repository.crt
   : "${JAVA_HOME:?[ERROR] JAVA_HOME not set or empty}"
-  cp  $JAVA_HOME/jre/lib/security/cacerts $working/security/.
+  if [ -d "$JAVA_HOME/jre/lib/security/cacerts" ]
+    then cp $JAVA_HOME/jre/lib/security/cacerts $working/security/.
+  fi
   keytool -noprompt -storepass changeit -keystore $working/security/cacerts -import -file $working/security/repository.crt -alias maven-resource-repository-CAAlias
   MAVEN_OPTS="$MAVEN_OPTS -Djavax.net.ssl.trustStore=$working/security/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
 fi

--- a/assets/out
+++ b/assets/out
@@ -96,7 +96,9 @@ elif [ -n "$repository_cert" ]; then
   mkdir -p $working/security
   echo "$repository_cert" > $working/security/repository.crt
   : "${JAVA_HOME:?[ERROR] JAVA_HOME not set or empty}"
-  cp  $JAVA_HOME/jre/lib/security/cacerts $working/security/.
+  if [ -d "$JAVA_HOME/jre/lib/security/cacerts" ]
+    then cp $JAVA_HOME/jre/lib/security/cacerts $working/security/.
+  fi
   keytool -noprompt -storepass changeit -keystore $working/security/cacerts -import -file $working/security/repository.crt -alias maven-resource-repository-CAAlias
   MAVEN_OPTS="$MAVEN_OPTS -Djavax.net.ssl.trustStore=$working/security/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
 fi


### PR DESCRIPTION
This invents a quick workaround for https://github.com/patrickcrocker/maven-resource/issues/20, so that at least using `repository_cert` with Concourse 3.9.0 works.

Why no test coverage?
We would need to import a valid certificate, using keytool (which checks x509 validity). There is no openssl in the container, so I assume tests would need to be written in itest. Because I have no clue what is possible on this nexus (at least I see a call to openssl), I have no idea how I could write tests and check them locally. So please be gentle :)