### PR TITLE
Fix snapshot default version

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -64,7 +64,7 @@ if [ -n "$uniqueVersion" ]; then
   version=$(echo ${version%-$uniqueVersion}-SNAPSHOT)
 fi
 
-url=$release_url
+url=${release_url:-${snapshot_url}}
 if [[ "$version" = *-SNAPSHOT ]]; then
   [ -n "$snapshot_url" ] && url=$snapshot_url
   metadataUrl="$url/${groupId//.//}/$artifactId/$version/maven-metadata.xml"


### PR DESCRIPTION
Add a null coalesce to the url so that it resolves to snapshot URL if undefined.